### PR TITLE
remove duplicate thumbnail in UserSerializer

### DIFF
--- a/backend/potluck/serializers.py
+++ b/backend/potluck/serializers.py
@@ -33,7 +33,6 @@ class UserSerializer(serializers.ModelSerializer):
             'date_joined',
             'full_name',
             'initials',
-            'thumbnail'
         )
 
         read_only_fields = ('date_joined',)


### PR DESCRIPTION
removed duplicate 'thumbnail' in UserSerializer that was missing a comma